### PR TITLE
Harden Supabase auth handling for invalid credentials

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const useSupabaseSetup = () => {
   const [error, setError] = React.useState<string | null>(null);
   const [isExpiredToken, setIsExpiredToken] = React.useState(false);
   const [isInvalidKey, setIsInvalidKey] = React.useState(false);
+  const [isBoltToken, setIsBoltToken] = React.useState(false);
 
   React.useEffect(() => {
     let mounted = true;
@@ -95,7 +96,7 @@ const useSupabaseSetup = () => {
           setError(healthCheck.error || null);
           setIsExpiredToken(healthCheck.isExpiredToken || false);
           setIsInvalidKey(healthCheck.isInvalidKey || false);
-          setIsInvalidKey(healthCheck.isInvalidKey || false);
+          setIsBoltToken(healthCheck.isBoltToken || false);
         }
       } catch (error) {
         if (mounted) {
@@ -116,7 +117,7 @@ const useSupabaseSetup = () => {
     };
   }, []);
 
-  return { setupComplete, checking, error, isExpiredToken, isInvalidKey, setSetupComplete };
+  return { setupComplete, checking, error, isExpiredToken, isInvalidKey, isBoltToken, setSetupComplete };
 };
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -33,6 +33,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const lastAuthEvent = useRef<{ event: string; timestamp: number } | null>(null);
 
   const ensureProfileExists = async (authUser: SupabaseUser): Promise<ProfileWithRelations | null> => {
+    if (!supabase) {
+      console.warn('Supabase client unavailable while ensuring profile.');
+      return null;
+    }
+
     const { data: existingProfile } = await supabase
       .from('profiles')
       .select('*')
@@ -115,6 +120,13 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         }
       }
     };
+
+    if (!supabase) {
+      setLoading(false);
+      return () => {
+        isMounted = false;
+      };
+    }
 
     initializeAuth();
 


### PR DESCRIPTION
## Summary
- stop instantiating the Supabase client when the URL format, token lifetime, or issuer indicates invalid credentials and improve health diagnostics
- guard the authentication context against a missing Supabase client to avoid reconnection loops and profile creation errors
- expose Bolt token detection to the setup flow so the UI can surface precise remediation guidance

## Testing
- npm run lint *(fails: existing lint warnings in untouched files)*

------
https://chatgpt.com/codex/tasks/task_b_68dc32adbbf083238a30e6fdf512de51