### PR TITLE
Fix lint hook violations in admin and calendar pages

### DIFF
--- a/src/pages/Administration.tsx
+++ b/src/pages/Administration.tsx
@@ -41,6 +41,7 @@ const Administration: React.FC = () => {
     maintenance_mode: false
   });
   const [configLoading, setConfigLoading] = useState(false);
+  const [auditLogs, setAuditLogs] = useState<any[]>([]);
 
   const tabs = [
     { id: 'system', label: 'Sistema', icon: <Settings size={16} /> },
@@ -56,6 +57,7 @@ const Administration: React.FC = () => {
   useEffect(() => {
     loadSystemStats();
     loadSystemConfig();
+    loadAuditLogs();
   }, []);
 
   const loadSystemStats = async () => {
@@ -93,6 +95,17 @@ const Administration: React.FC = () => {
       }
     } catch (error) {
       console.error('Error loading system config:', error);
+    }
+  };
+
+  const loadAuditLogs = async () => {
+    try {
+      const { adminService } = await import('../services/admin');
+      const logs = await adminService.getAuditLogs(10);
+      setAuditLogs(logs ?? []);
+    } catch (error) {
+      console.error('Error loading audit logs:', error);
+      setAuditLogs([]);
     }
   };
 
@@ -458,24 +471,7 @@ const Administration: React.FC = () => {
           <Card className="p-6">
             <h3 className="text-lg font-semibold mb-4">Log de Auditoria</h3>
             <div className="space-y-3 max-h-64 overflow-y-auto">
-              {React.useMemo(() => {
-                const [auditLogs, setAuditLogs] = React.useState<any[]>([]);
-                
-                React.useEffect(() => {
-                  const loadLogs = async () => {
-                    try {
-                      const { adminService } = await import('../services/admin');
-                      const logs = await adminService.getAuditLogs(10);
-                      setAuditLogs(logs);
-                    } catch (error) {
-                      console.error('Error loading audit logs:', error);
-                    }
-                  };
-                  loadLogs();
-                }, []);
-                
-                return auditLogs;
-              }, []).map((log, index) => (
+              {auditLogs.map((log, index) => (
                 <div key={log.id || index} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div>
                     <span className="font-medium text-gray-900">{log.action}</span>
@@ -491,6 +487,9 @@ const Administration: React.FC = () => {
                   </div>
                 </div>
               ))}
+              {auditLogs.length === 0 && (
+                <p className="text-sm text-gray-500 text-center">Nenhum registro de auditoria disponível.</p>
+              )}
             </div>
           </Card>
         </div>

--- a/src/pages/HRCalendar.tsx
+++ b/src/pages/HRCalendar.tsx
@@ -91,10 +91,11 @@ const HRCalendar: React.FC = () => {
     switch (viewMode) {
       case 'month':
         return new Date(date.getFullYear(), date.getMonth(), 1).toISOString().split('T')[0];
-      case 'week':
+      case 'week': {
         const startOfWeek = new Date(date);
         startOfWeek.setDate(date.getDate() - date.getDay());
         return startOfWeek.toISOString().split('T')[0];
+      }
       case 'day':
         return date.toISOString().split('T')[0];
       default:
@@ -107,10 +108,11 @@ const HRCalendar: React.FC = () => {
     switch (viewMode) {
       case 'month':
         return new Date(date.getFullYear(), date.getMonth() + 1, 0).toISOString().split('T')[0];
-      case 'week':
+      case 'week': {
         const endOfWeek = new Date(date);
         endOfWeek.setDate(date.getDate() - date.getDay() + 6);
         return endOfWeek.toISOString().split('T')[0];
+      }
       case 'day':
         return date.toISOString().split('T')[0];
       default:
@@ -182,16 +184,17 @@ const HRCalendar: React.FC = () => {
 
   const getDateRangeLabel = (): string => {
     const date = new Date(selectedDate);
-    
+
     switch (viewMode) {
       case 'month':
         return date.toLocaleDateString('pt-BR', { month: 'long', year: 'numeric' });
-      case 'week':
+      case 'week': {
         const startOfWeek = new Date(date);
         startOfWeek.setDate(date.getDate() - date.getDay());
         const endOfWeek = new Date(startOfWeek);
         endOfWeek.setDate(startOfWeek.getDate() + 6);
         return `${startOfWeek.toLocaleDateString('pt-BR')} - ${endOfWeek.toLocaleDateString('pt-BR')}`;
+      }
       case 'day':
         return date.toLocaleDateString('pt-BR', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
       default:

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -47,20 +47,23 @@ const Reports: React.FC = () => {
     setLoading(true);
     try {
       switch (selectedReport) {
-        case 'performance':
+        case 'performance': {
           const perfData = await reportService.generatePerformanceReport(
             user?.role === 'manager' ? user.id : undefined
           );
           setPerformanceData(perfData);
           break;
-        case 'team':
+        }
+        case 'team': {
           const teamData = await reportService.generateTeamReport();
           setTeamData(teamData);
           break;
-        case 'competency':
+        }
+        case 'competency': {
           const gapData = await reportService.generateCompetencyGapReport();
           setCompetencyGaps(gapData);
           break;
+        }
       }
     } catch (error) {
       console.error('Error loading report data:', error);


### PR DESCRIPTION
## Summary
- manage administration audit logs with top-level state/effect instead of nested hooks
- wrap HR calendar switch cases in block scopes to satisfy lint rules for lexical declarations
- scope report data fetch switch cases to avoid lint errors

## Testing
- npx eslint . --quiet
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dc3aec43408323a367c67dc23d7369