### PR TITLE
Handle dynamic Supabase configuration updates

### DIFF
--- a/src/components/SetupCheck.tsx
+++ b/src/components/SetupCheck.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from './ui/Button';
 import { Input } from './ui/Input';
 import { Card } from './ui/Card';
+import { initializeSupabaseClient } from '../lib/supabase';
 
 interface SetupStatus {
   hasUrl: boolean;
@@ -194,9 +195,11 @@ export const SetupCheck: React.FC<SetupCheckProps> = ({ onSetupComplete, initial
         authEnabled,
         projectOnline: true
       }));
-      
+
       console.log('✅ SetupCheck: All tests passed!');
       clearTimeout(timeoutId);
+      localStorage.removeItem('OFFLINE_MODE');
+      initializeSupabaseClient(true);
 
     } catch (error: any) {
       clearTimeout(timeoutId);
@@ -241,6 +244,7 @@ export const SetupCheck: React.FC<SetupCheckProps> = ({ onSetupComplete, initial
   const enableOfflineMode = () => {
     setOfflineMode(true);
     localStorage.setItem('OFFLINE_MODE', 'true');
+    initializeSupabaseClient(true);
     onSetupComplete();
   };
 


### PR DESCRIPTION
## Summary
- add a reusable Supabase initialization helper that reads manual credentials or offline mode overrides and notifies listeners when the config changes
- update the authentication provider to react to Supabase client changes, re-run initialization safely, and guard profile refresh/sign-in when the client is unavailable
- reinitialize the Supabase client after manual setup tests or when enabling offline mode so the login flow can continue without a reload

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68dc632e31388323bdbcce3130cb8d29