### PR TITLE
Remove duplicate HR calendar route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -368,14 +368,6 @@ const AppRoutes: React.FC = () => {
           </ProtectedRoute>
         }
       />
-      <Route
-        path="/hr-calendar"
-        element={
-          <ProtectedRoute>
-            <LazyHRCalendar />
-          </ProtectedRoute>
-        }
-      />
       <Route path="/" element={<Navigate to="/dashboard" replace />} />
       </Routes>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary
- remove the duplicate `/hr-calendar` route definition so it is only registered once

## Testing
- npm test -- --runInBand *(fails: ReferenceError: module is not defined in jest.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68dd2c78ef208323b3e88d382f01caa8