### PR TITLE
fix: update Jest moduleNameMapper option

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
-module.exports = {
+export default {
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1'
   },


### PR DESCRIPTION
## Summary
- rename the Jest configuration option to moduleNameMapper to match current schema
- convert the Jest config file to ESM export so it can be loaded when the package type is module

## Testing
- npm test *(fails: Module ts-jest in the transform option was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68dd2c7b4430832387e3aa3087b9df3a