### PR TITLE
Create avatars storage bucket and policies

### DIFF
--- a/supabase/migrations/20251004120000_create_avatars_bucket.sql
+++ b/supabase/migrations/20251004120000_create_avatars_bucket.sql
@@ -1,0 +1,49 @@
+-- Create avatars bucket if it doesn't exist yet
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do update
+set public = excluded.public;
+
+-- Allow public read access to avatar images
+drop policy if exists "Avatar images are publicly accessible" on storage.objects;
+create policy "Avatar images are publicly accessible"
+  on storage.objects for select
+  using (bucket_id = 'avatars');
+
+-- Allow authenticated users to manage their own avatar files
+-- Avatar files are stored with the pattern `${userId}/filename`
+-- so we restrict changes to the folder that matches the current user id
+
+-- Insert
+drop policy if exists "Users can upload their own avatars" on storage.objects;
+create policy "Users can upload their own avatars"
+  on storage.objects for insert
+  to authenticated
+  with check (
+    bucket_id = 'avatars'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+-- Update
+drop policy if exists "Users can update their own avatars" on storage.objects;
+create policy "Users can update their own avatars"
+  on storage.objects for update
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and split_part(name, '/', 1) = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'avatars'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+-- Delete
+drop policy if exists "Users can delete their own avatars" on storage.objects;
+create policy "Users can delete their own avatars"
+  on storage.objects for delete
+  to authenticated
+  using (
+    bucket_id = 'avatars'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary
- add a migration that creates the Supabase `avatars` bucket when missing
- define storage policies so authenticated users can manage their own avatar files

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68dd3087c30c8323b424140e7e642932