### PR TITLE
Add SetupCheck tests and shared mocks

### DIFF
--- a/src/components/__tests__/SetupCheck.test.tsx
+++ b/src/components/__tests__/SetupCheck.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { SetupCheck } from '../SetupCheck';
+import { initializeSupabaseClient } from '../../lib/supabase';
+
+describe('SetupCheck', () => {
+  const originalFetch = global.fetch;
+  const ensureEnv = () => {
+    const meta = import.meta as unknown as { env: Record<string, any> | undefined };
+    if (!meta.env) {
+      meta.env = {};
+    }
+    return meta.env;
+  };
+  const originalEnv = { ...ensureEnv() };
+
+  const setEnv = (overrides: Record<string, string | undefined>) => {
+    const meta = import.meta as unknown as { env: Record<string, any> };
+    meta.env = { ...originalEnv, ...overrides };
+  };
+
+  const getFetchMock = () => global.fetch as jest.Mock;
+  const getInitializeSupabaseClientMock = () => initializeSupabaseClient as jest.MockedFunction<typeof initializeSupabaseClient>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    setEnv({});
+    global.fetch = jest.fn() as unknown as typeof global.fetch;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    setEnv({});
+    global.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    const meta = import.meta as unknown as { env: Record<string, any> };
+    meta.env = { ...originalEnv };
+  });
+
+  it('exibe configuração manual quando variáveis de ambiente estão ausentes', async () => {
+    setEnv({
+      VITE_SUPABASE_URL: undefined,
+      VITE_SUPABASE_ANON_KEY: undefined
+    });
+
+    render(<SetupCheck onSetupComplete={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('URL do Supabase')).toBeInTheDocument();
+      expect(screen.getByLabelText('Chave Anônima (Anon Key)')).toBeInTheDocument();
+    });
+
+    expect(getFetchMock()).not.toHaveBeenCalled();
+  });
+
+  it('realiza fluxo de sucesso realizando múltiplos fetch e inicializa Supabase', async () => {
+    const url = 'https://example.supabase.co';
+    const key = 'anon-key';
+    setEnv({
+      VITE_SUPABASE_URL: url,
+      VITE_SUPABASE_ANON_KEY: key
+    });
+
+    const fetchMock = getFetchMock();
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: jest.fn().mockResolvedValue({ external_email_enabled: true })
+      } as unknown as Response)
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' } as Response);
+
+    render(<SetupCheck onSetupComplete={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('✅ Supabase Configurado!')).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, `${url}/rest/v1/`, expect.objectContaining({ headers: expect.any(Object) }));
+    expect(fetchMock).toHaveBeenNthCalledWith(2, `${url}/auth/v1/settings`, expect.any(Object));
+    expect(fetchMock).toHaveBeenNthCalledWith(3, `${url}/rest/v1/profiles?select=count&head=true`, expect.objectContaining({ method: 'HEAD' }));
+
+    const removeItemMock = window.localStorage.removeItem as jest.Mock;
+    expect(removeItemMock).toHaveBeenCalledWith('OFFLINE_MODE');
+
+    const initializeMock = getInitializeSupabaseClientMock();
+    expect(initializeMock).toHaveBeenCalledWith(true);
+  });
+
+  it.each([
+    {
+      status: 401,
+      statusText: 'Unauthorized',
+      expected: 'Chave de API inválida. Verifique se a ANON_KEY está correta.'
+    },
+    {
+      status: 404,
+      statusText: 'Not Found',
+      expected: 'Projeto não encontrado. Verifique se a URL do Supabase está correta.'
+    }
+  ])('mapeia erro HTTP $status para mensagem amigável', async ({ status, statusText, expected }) => {
+    const url = 'https://example.supabase.co';
+    const key = 'anon-key';
+    setEnv({
+      VITE_SUPABASE_URL: url,
+      VITE_SUPABASE_ANON_KEY: key
+    });
+
+    const fetchMock = getFetchMock();
+    fetchMock.mockResolvedValueOnce({ ok: false, status, statusText } as Response);
+
+    render(<SetupCheck onSetupComplete={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('apresenta mensagem de timeout quando a conexão demora demais', async () => {
+    const url = 'https://example.supabase.co';
+    const key = 'anon-key';
+    setEnv({
+      VITE_SUPABASE_URL: url,
+      VITE_SUPABASE_ANON_KEY: key
+    });
+
+    const fetchMock = getFetchMock();
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+
+    render(<SetupCheck onSetupComplete={jest.fn()} />);
+
+    await act(async () => {
+      jest.advanceTimersByTime(10000);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Connection test timed out. Please check your Supabase configuration.')).toBeInTheDocument();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('habilita modo offline e executa callbacks ao acionar o botão', () => {
+    setEnv({
+      VITE_SUPABASE_URL: undefined,
+      VITE_SUPABASE_ANON_KEY: undefined
+    });
+
+    const onSetupComplete = jest.fn();
+    const initializeMock = getInitializeSupabaseClientMock();
+
+    render(<SetupCheck onSetupComplete={onSetupComplete} />);
+
+    const offlineButton = screen.getByRole('button', { name: /Continuar em Modo Offline/i });
+    fireEvent.click(offlineButton);
+
+    const setItemMock = window.localStorage.setItem as jest.Mock;
+    expect(setItemMock).toHaveBeenCalledWith('OFFLINE_MODE', 'true');
+    expect(initializeMock).toHaveBeenCalledWith(true);
+    expect(onSetupComplete).toHaveBeenCalled();
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,25 +1,69 @@
 import '@testing-library/jest-dom';
 
-// Mock Supabase
+// Shared mocks --------------------------------------------------------------
+
+const createLocalStorageMock = () => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: jest.fn((key: string) => (key in store ? store[key] : null)),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    key: jest.fn((index: number) => Object.keys(store)[index] ?? null),
+    get length() {
+      return Object.keys(store).length;
+    }
+  };
+};
+
+const localStorageMock = createLocalStorageMock();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock as unknown as Storage,
+  configurable: true
+});
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    writeText: jest.fn()
+  },
+  configurable: true
+});
+
+// Mock Supabase -------------------------------------------------------------
+
+const mockSupabase = {
+  auth: {
+    signInWithPassword: jest.fn(),
+    signUp: jest.fn(),
+    signOut: jest.fn(),
+    getSession: jest.fn(),
+    onAuthStateChange: jest.fn()
+  },
+  from: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn(),
+    maybeSingle: jest.fn()
+  }))
+};
+
+const mockInitializeSupabaseClient = jest.fn();
+
 jest.mock('./lib/supabase', () => ({
-  supabase: {
-    auth: {
-      signInWithPassword: jest.fn(),
-      signUp: jest.fn(),
-      signOut: jest.fn(),
-      getSession: jest.fn(),
-      onAuthStateChange: jest.fn()
-    },
-    from: jest.fn(() => ({
-      select: jest.fn().mockReturnThis(),
-      insert: jest.fn().mockReturnThis(),
-      update: jest.fn().mockReturnThis(),
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      single: jest.fn(),
-      maybeSingle: jest.fn()
-    }))
-  }
+  __esModule: true,
+  supabase: mockSupabase,
+  initializeSupabaseClient: mockInitializeSupabaseClient
 }));
 
 // Mock window.matchMedia


### PR DESCRIPTION
## Summary
- add comprehensive SetupCheck test coverage for manual setup, success, timeout, and error flows
- mock clipboard, offline storage, and Supabase initialization helpers in the shared Jest setup

## Testing
- npm test -- SetupCheck *(fails: Module ts-jest in the transform option was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68dd3d544a28832389d0501858976152