### PR TITLE
Add HR calendar service tests and HR workflow Cypress coverage

### DIFF
--- a/cypress/e2e/hr-workflows.cy.ts
+++ b/cypress/e2e/hr-workflows.cy.ts
@@ -1,0 +1,105 @@
+describe('HR Workflows', () => {
+  beforeEach(() => {
+    cy.setTestUser('hr');
+    cy.intercept('GET', '**/rest/v1/profiles*', { fixture: 'hr/profiles.json' }).as('getProfiles');
+    cy.intercept('GET', '**/rest/v1/pdis*', { fixture: 'hr/pdis.json' }).as('getPendingPdis');
+    cy.intercept('GET', '**/rest/v1/competencies*', { fixture: 'hr/competencies.json' }).as('getCompetencies');
+  });
+
+  it('loads the HR area overview with key dashboards', () => {
+    cy.visit('/hr');
+    cy.wait(['@getProfiles', '@getPendingPdis', '@getCompetencies']);
+
+    cy.contains('Área de RH').should('be.visible');
+    cy.contains('Total Colaboradores').prev().should('contain', '3');
+    cy.contains('Ativos').prev().should('contain', '2');
+    cy.contains('Distribuição por Função').should('be.visible');
+    cy.contains('Tendência de Engajamento').should('be.visible');
+    cy.contains('Lista de Colaboradores').should('be.visible');
+    cy.contains('Colaborador Teste').should('be.visible');
+  });
+
+  it('approves vacation requests and refreshes HR calendar metrics', () => {
+    let useApprovedEvents = false;
+    let useApprovedRequests = false;
+
+    cy.intercept('GET', '**/rest/v1/calendar_events*', (req) => {
+      req.reply({ fixture: useApprovedEvents ? 'hr/calendar-events-approved.json' : 'hr/calendar-events.json' });
+    }).as('getCalendarEvents');
+
+    cy.intercept('GET', '**/rest/v1/calendar_requests*', (req) => {
+      req.reply({ fixture: useApprovedRequests ? 'hr/calendar-requests-approved.json' : 'hr/calendar-requests.json' });
+    }).as('getCalendarRequests');
+
+    cy.intercept('PATCH', '**/rest/v1/calendar_requests*', (req) => {
+      useApprovedRequests = true;
+      req.reply({ body: [{ ...req.body, status: 'approved', hr_approval: true }] });
+    }).as('approveCalendarRequest');
+
+    cy.intercept('POST', '**/rest/v1/calendar_events', {
+      body: [{ id: 'evt-003' }]
+    }).as('createCalendarEvent');
+
+    cy.intercept('POST', '**/rest/v1/calendar_notifications', {
+      body: [{ id: 'notification-001' }]
+    }).as('createCalendarNotification');
+
+    cy.visit('/hr-calendar');
+    cy.wait('@getCalendarEvents');
+    cy.wait('@getCalendarRequests');
+
+    cy.contains('Total Eventos').prev().should('contain', '2');
+    cy.contains('Pendentes').prev().should('contain', '1');
+
+    cy.contains('Aprovações').click();
+    cy.contains('Aprovar').click();
+    cy.get('textarea').type('Aprovado automaticamente pelos testes.');
+
+    useApprovedEvents = true;
+    cy.contains('Confirmar Aprovação').click();
+
+    cy.wait(['@approveCalendarRequest', '@createCalendarEvent', '@createCalendarNotification']);
+    cy.wait('@getCalendarEvents');
+    cy.wait('@getCalendarRequests');
+
+    cy.contains('Total Eventos').prev().should('contain', '3');
+    cy.contains('Pendentes').prev().should('contain', '0');
+    cy.contains('Aprovações').click();
+    cy.contains('Nenhuma solicitação pendente').should('be.visible');
+  });
+
+  it('rejects vacation requests and shows rejection feedback', () => {
+    let useRejectedRequests = false;
+
+    cy.intercept('GET', '**/rest/v1/calendar_events*', { fixture: 'hr/calendar-events.json' }).as('getCalendarEvents');
+    cy.intercept('GET', '**/rest/v1/calendar_requests*', (req) => {
+      req.reply({ fixture: useRejectedRequests ? 'hr/calendar-requests-rejected.json' : 'hr/calendar-requests.json' });
+    }).as('getCalendarRequests');
+
+    cy.intercept('PATCH', '**/rest/v1/calendar_requests*', (req) => {
+      useRejectedRequests = true;
+      req.reply({ body: [{ ...req.body, status: 'rejected', hr_approval: false, rejection_reason: 'Conflito de agenda' }] });
+    }).as('rejectCalendarRequest');
+
+    cy.intercept('POST', '**/rest/v1/calendar_notifications', {
+      body: [{ id: 'notification-002' }]
+    }).as('createRejectionNotification');
+
+    cy.visit('/hr-calendar');
+    cy.wait('@getCalendarEvents');
+    cy.wait('@getCalendarRequests');
+
+    cy.contains('Aprovações').click();
+    cy.contains('Rejeitar').click();
+    cy.get('textarea').type('Conflito de agenda identificado.');
+
+    cy.contains('Confirmar Rejeição').click();
+
+    cy.wait(['@rejectCalendarRequest', '@createRejectionNotification']);
+    cy.wait('@getCalendarRequests');
+
+    cy.contains('Aprovações').click();
+    cy.contains('Rejeitado').should('be.visible');
+    cy.contains('Conflito de agenda').should('be.visible');
+  });
+});

--- a/cypress/fixtures/hr/calendar-events-approved.json
+++ b/cypress/fixtures/hr/calendar-events-approved.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "evt-001",
+    "type": "ferias",
+    "title": "Férias - Colaborador Teste",
+    "description": "Período de descanso",
+    "start_date": "2024-02-10",
+    "end_date": "2024-02-20",
+    "all_day": true,
+    "category": "vacation",
+    "status": "confirmed",
+    "user_id": "employee-user-id",
+    "is_public": true,
+    "color": "#F59E0B",
+    "created_at": "2024-01-01",
+    "updated_at": "2024-01-01"
+  },
+  {
+    "id": "evt-002",
+    "type": "aniversario",
+    "title": "Aniversário - Especialista RH",
+    "description": "Celebração de aniversário",
+    "start_date": "2024-03-05",
+    "end_date": "2024-03-05",
+    "all_day": true,
+    "category": "birthday",
+    "status": "confirmed",
+    "user_id": "hr-user-id",
+    "is_public": true,
+    "color": "#3B82F6",
+    "created_at": "2024-02-01",
+    "updated_at": "2024-02-01"
+  },
+  {
+    "id": "evt-003",
+    "type": "ferias",
+    "title": "Férias - Gestor Estratégico",
+    "description": "Período aprovado pelo RH",
+    "start_date": "2024-04-10",
+    "end_date": "2024-04-18",
+    "all_day": true,
+    "category": "vacation",
+    "status": "confirmed",
+    "user_id": "manager-user-id",
+    "is_public": true,
+    "color": "#F59E0B",
+    "created_at": "2024-02-20",
+    "updated_at": "2024-02-20"
+  }
+]

--- a/cypress/fixtures/hr/calendar-events.json
+++ b/cypress/fixtures/hr/calendar-events.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "evt-001",
+    "type": "ferias",
+    "title": "Férias - Colaborador Teste",
+    "description": "Período de descanso",
+    "start_date": "2024-02-10",
+    "end_date": "2024-02-20",
+    "all_day": true,
+    "category": "vacation",
+    "status": "confirmed",
+    "user_id": "employee-user-id",
+    "is_public": true,
+    "color": "#F59E0B",
+    "created_at": "2024-01-01",
+    "updated_at": "2024-01-01"
+  },
+  {
+    "id": "evt-002",
+    "type": "aniversario",
+    "title": "Aniversário - Especialista RH",
+    "description": "Celebração de aniversário",
+    "start_date": "2024-03-05",
+    "end_date": "2024-03-05",
+    "all_day": true,
+    "category": "birthday",
+    "status": "confirmed",
+    "user_id": "hr-user-id",
+    "is_public": true,
+    "color": "#3B82F6",
+    "created_at": "2024-02-01",
+    "updated_at": "2024-02-01"
+  }
+]

--- a/cypress/fixtures/hr/calendar-requests-approved.json
+++ b/cypress/fixtures/hr/calendar-requests-approved.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "req-001",
+    "event_type": "ferias",
+    "requester_id": "employee-user-id",
+    "start_date": "2024-04-10",
+    "end_date": "2024-04-18",
+    "reason": "Viagem com a família",
+    "status": "approved",
+    "manager_approval": true,
+    "hr_approval": true,
+    "comments": "Aprovado pelo RH",
+    "days_requested": 6,
+    "created_at": "2024-02-18T12:00:00Z",
+    "updated_at": "2024-02-20T08:00:00Z",
+    "requester": {
+      "id": "employee-user-id",
+      "name": "Colaborador Teste",
+      "position": "Analista de Produto",
+      "team": { "name": "Produto" }
+    }
+  }
+]

--- a/cypress/fixtures/hr/calendar-requests-rejected.json
+++ b/cypress/fixtures/hr/calendar-requests-rejected.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "req-001",
+    "event_type": "ferias",
+    "requester_id": "employee-user-id",
+    "start_date": "2024-04-10",
+    "end_date": "2024-04-18",
+    "reason": "Viagem com a família",
+    "status": "rejected",
+    "manager_approval": true,
+    "hr_approval": false,
+    "rejection_reason": "Conflito de agenda",
+    "days_requested": 6,
+    "created_at": "2024-02-18T12:00:00Z",
+    "updated_at": "2024-02-20T09:00:00Z",
+    "requester": {
+      "id": "employee-user-id",
+      "name": "Colaborador Teste",
+      "position": "Analista de Produto",
+      "team": { "name": "Produto" }
+    }
+  }
+]

--- a/cypress/fixtures/hr/calendar-requests.json
+++ b/cypress/fixtures/hr/calendar-requests.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "req-001",
+    "event_type": "ferias",
+    "requester_id": "employee-user-id",
+    "start_date": "2024-04-10",
+    "end_date": "2024-04-18",
+    "reason": "Viagem com a família",
+    "status": "pending",
+    "manager_approval": true,
+    "hr_approval": false,
+    "comments": null,
+    "days_requested": 6,
+    "created_at": "2024-02-18T12:00:00Z",
+    "updated_at": "2024-02-18T12:00:00Z",
+    "requester": {
+      "id": "employee-user-id",
+      "name": "Colaborador Teste",
+      "position": "Analista de Produto",
+      "team": { "name": "Produto" }
+    }
+  }
+]

--- a/cypress/fixtures/hr/competencies.json
+++ b/cypress/fixtures/hr/competencies.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "comp-001",
+    "name": "Liderança Colaborativa",
+    "type": "soft_skill",
+    "stage": "Desenvolvimento",
+    "profile_id": "employee-user-id",
+    "self_rating": 2,
+    "manager_rating": 3,
+    "target_level": 5,
+    "profile": {
+      "name": "Colaborador Teste",
+      "position": "Analista de Produto",
+      "level": "Pleno"
+    }
+  },
+  {
+    "id": "comp-002",
+    "name": "Gestão de Projetos",
+    "type": "hard_skill",
+    "stage": "Avançado",
+    "profile_id": "manager-user-id",
+    "self_rating": 4,
+    "manager_rating": 4,
+    "target_level": 5,
+    "profile": {
+      "name": "Gestor Estratégico",
+      "position": "Head de Operações",
+      "level": "Sênior"
+    }
+  }
+]

--- a/cypress/fixtures/hr/pdis.json
+++ b/cypress/fixtures/hr/pdis.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "pdi-001",
+    "title": "Plano de Carreira Avançado",
+    "status": "completed",
+    "created_at": "2024-01-12T10:00:00Z",
+    "profile_id": "employee-user-id",
+    "profile": {
+      "name": "Colaborador Teste",
+      "position": "Analista de Produto"
+    },
+    "mentor": {
+      "name": "Especialista RH"
+    }
+  }
+]

--- a/cypress/fixtures/hr/profiles.json
+++ b/cypress/fixtures/hr/profiles.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "hr-user-id",
+    "name": "Especialista RH",
+    "email": "rh@example.com",
+    "role": "hr",
+    "position": "Business Partner",
+    "level": "Sênior",
+    "points": 1200,
+    "status": "active",
+    "team": { "name": "Recursos Humanos" },
+    "avatar_url": "https://images.pexels.com/photos/2379005/pexels-photo-2379005.jpeg?w=150&h=150&fit=crop&crop=face"
+  },
+  {
+    "id": "employee-user-id",
+    "name": "Colaborador Teste",
+    "email": "colaborador@example.com",
+    "role": "employee",
+    "position": "Analista de Produto",
+    "level": "Pleno",
+    "points": 980,
+    "status": "active",
+    "team": { "name": "Produto" },
+    "avatar_url": "https://images.pexels.com/photos/2381069/pexels-photo-2381069.jpeg?w=150&h=150&fit=crop&crop=face"
+  },
+  {
+    "id": "manager-user-id",
+    "name": "Gestor Estratégico",
+    "email": "gestor@example.com",
+    "role": "manager",
+    "position": "Head de Operações",
+    "level": "Sênior",
+    "points": 1500,
+    "status": "inactive",
+    "team": { "name": "Operações" },
+    "avatar_url": "https://images.pexels.com/photos/2446734/pexels-photo-2446734.jpeg?w=150&h=150&fit=crop&crop=face"
+  }
+]

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -6,7 +6,7 @@ declare global {
       login(email: string, password: string): Chainable<void>;
       createTestUser(): Chainable<void>;
       cleanupTestData(): Chainable<void>;
-      setTestUser(role?: 'employee' | 'hr', overrides?: Record<string, any>): Chainable<void>;
+      setTestUser(role?: 'employee' | 'hr' | 'admin', overrides?: Record<string, any>): Chainable<void>;
     }
   }
 }
@@ -40,14 +40,30 @@ Cypress.Commands.add('cleanupTestData', () => {
   cy.clearCookies();
 });
 
-Cypress.Commands.add('setTestUser', (role: 'employee' | 'hr' = 'employee', overrides: Record<string, any> = {}) => {
+Cypress.Commands.add('setTestUser', (role: 'employee' | 'hr' | 'admin' = 'employee', overrides: Record<string, any> = {}) => {
   cy.window().then((win) => {
+    const baseEmail = role === 'admin'
+      ? 'admin@example.com'
+      : role === 'hr'
+        ? 'rh@example.com'
+        : 'colaborador@example.com';
+    const baseName = role === 'admin'
+      ? 'Administrador Talento'
+      : role === 'hr'
+        ? 'Especialista RH'
+        : 'Colaborador Teste';
+    const basePosition = role === 'admin'
+      ? 'Chief Talent Officer'
+      : role === 'hr'
+        ? 'Business Partner'
+        : 'Analista';
+
     const baseUser = {
-      id: role === 'hr' ? 'hr-user-id' : 'employee-user-id',
-      email: role === 'hr' ? 'rh@example.com' : 'colaborador@example.com',
-      name: role === 'hr' ? 'Especialista RH' : 'Colaborador Teste',
+      id: role === 'admin' ? 'admin-user-id' : role === 'hr' ? 'hr-user-id' : 'employee-user-id',
+      email: baseEmail,
+      name: baseName,
       role,
-      position: role === 'hr' ? 'Business Partner' : 'Analista',
+      position: basePosition,
       level: 'Pleno',
       mental_health_consent: role === 'employee',
       ...overrides

--- a/src/services/__tests__/hrCalendarService.test.ts
+++ b/src/services/__tests__/hrCalendarService.test.ts
@@ -1,0 +1,383 @@
+import type { CalendarEvent, CalendarRequest } from '../hrCalendar';
+
+const supabaseRequestMock = jest.fn();
+
+interface QueryOptions {
+  orderResult?: { data: any; error: any };
+  singleResult?: { data: any; error: any };
+  eqReturn?: any;
+}
+
+const createQueryBuilder = (options: QueryOptions = {}) => {
+  const builder: any = {};
+
+  builder.select = jest.fn().mockReturnValue(builder);
+  builder.insert = jest.fn().mockReturnValue(builder);
+  builder.update = jest.fn().mockReturnValue(builder);
+  builder.delete = jest.fn().mockReturnValue(builder);
+  builder.gte = jest.fn().mockReturnValue(builder);
+  builder.lte = jest.fn().mockReturnValue(builder);
+  builder.eq = jest.fn().mockImplementation(() => (options.eqReturn !== undefined ? options.eqReturn : builder));
+  builder.order = jest.fn().mockResolvedValue(options.orderResult ?? { data: [], error: null });
+  builder.single = jest.fn().mockResolvedValue(options.singleResult ?? { data: null, error: null });
+  builder.then = jest.fn();
+  builder.is = jest.fn().mockReturnValue(builder);
+
+  return builder;
+};
+
+const loadService = async (supabaseMock: any) => {
+  jest.resetModules();
+  supabaseRequestMock.mockReset();
+  supabaseRequestMock.mockImplementation(async (operation: any) => {
+    const result = await operation();
+    return result?.data ?? result;
+  });
+
+  jest.doMock('../../lib/supabase', () => ({
+    supabase: supabaseMock
+  }));
+
+  jest.doMock('../api', () => ({
+    supabaseRequest: supabaseRequestMock
+  }));
+
+  const module = await import('../hrCalendar');
+  return module.hrCalendarService;
+};
+
+const createSupabaseMock = (handlers: { [table: string]: any }, rpcMock?: jest.Mock) => ({
+  from: jest.fn((table: string) => {
+    if (!handlers[table]) {
+      throw new Error(`Unhandled table ${table}`);
+    }
+    return handlers[table];
+  }),
+  rpc: rpcMock ?? jest.fn()
+});
+
+describe('hrCalendarService', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  describe('getEvents', () => {
+    it('applies filters and returns events from Supabase', async () => {
+      const events: CalendarEvent[] = [
+        {
+          id: 'evt-1',
+          type: 'ferias',
+          title: 'Férias João',
+          start_date: '2024-01-01',
+          end_date: '2024-01-10',
+          all_day: true,
+          category: 'vacation',
+          status: 'approved',
+          is_public: true,
+          color: '#F59E0B',
+          created_at: '2023-12-01',
+          updated_at: '2023-12-01'
+        } as CalendarEvent
+      ];
+
+      const eventsQuery = createQueryBuilder({
+        orderResult: { data: events, error: null }
+      });
+
+      const supabaseMock = createSupabaseMock({
+        calendar_events: eventsQuery
+      });
+
+      const service = await loadService(supabaseMock as any);
+
+      const filters = {
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+        type: 'ferias',
+        user_id: 'user-1',
+        team_id: 'team-1',
+        is_public: true
+      };
+
+      const result = await service.getEvents(filters);
+
+      expect(supabaseMock.from).toHaveBeenCalledWith('calendar_events');
+      expect(eventsQuery.gte).toHaveBeenCalledWith('start_date', filters.start_date);
+      expect(eventsQuery.lte).toHaveBeenCalledWith('end_date', filters.end_date);
+      expect(eventsQuery.eq).toHaveBeenCalledWith('type', filters.type);
+      expect(eventsQuery.eq).toHaveBeenCalledWith('user_id', filters.user_id);
+      expect(eventsQuery.eq).toHaveBeenCalledWith('team_id', filters.team_id);
+      expect(eventsQuery.eq).toHaveBeenCalledWith('is_public', filters.is_public);
+      expect(supabaseRequestMock).toHaveBeenCalledWith(expect.any(Function), 'getCalendarEvents');
+      expect(result).toEqual(events);
+    });
+
+    it('returns empty array and logs warning when Supabase is unavailable', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const service = await loadService(null);
+      const result = await service.getEvents();
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledWith('📅 HRCalendar: Supabase not available');
+      expect(supabaseRequestMock).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('getRequests', () => {
+    it('applies filters and returns requests ordered by creation date', async () => {
+      const requests: CalendarRequest[] = [
+        {
+          id: 'req-1',
+          event_type: 'ferias',
+          requester_id: 'user-1',
+          start_date: '2024-02-01',
+          end_date: '2024-02-10',
+          reason: 'Viagem',
+          status: 'pending',
+          days_requested: 7,
+          created_at: '2023-12-15',
+          updated_at: '2023-12-15'
+        } as CalendarRequest
+      ];
+
+      const requestsQuery = createQueryBuilder({
+        orderResult: { data: requests, error: null }
+      });
+
+      const supabaseMock = createSupabaseMock({
+        calendar_requests: requestsQuery
+      });
+
+      const service = await loadService(supabaseMock as any);
+
+      const filters = {
+        requester_id: 'user-1',
+        status: 'pending',
+        event_type: 'ferias'
+      };
+
+      const result = await service.getRequests(filters);
+
+      expect(supabaseMock.from).toHaveBeenCalledWith('calendar_requests');
+      expect(requestsQuery.eq).toHaveBeenCalledWith('requester_id', filters.requester_id);
+      expect(requestsQuery.eq).toHaveBeenCalledWith('status', filters.status);
+      expect(requestsQuery.eq).toHaveBeenCalledWith('event_type', filters.event_type);
+      expect(requestsQuery.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(supabaseRequestMock).toHaveBeenCalledWith(expect.any(Function), 'getCalendarRequests');
+      expect(result).toEqual(requests);
+    });
+  });
+
+  describe('event mutations', () => {
+    it('creates events using Supabase and returns the created record', async () => {
+      const createdEvent = {
+        id: 'evt-123',
+        type: 'evento',
+        title: 'Workshop',
+        start_date: '2024-03-01',
+        end_date: '2024-03-01',
+        all_day: false,
+        category: 'training',
+        status: 'confirmed',
+        is_public: true,
+        color: '#000000',
+        created_at: '2024-02-10',
+        updated_at: '2024-02-10'
+      } as CalendarEvent;
+
+      const eventsQuery = createQueryBuilder({
+        singleResult: { data: createdEvent, error: null }
+      });
+
+      const supabaseMock = createSupabaseMock({
+        calendar_events: eventsQuery
+      });
+
+      const service = await loadService(supabaseMock as any);
+
+      const input = {
+        type: 'evento',
+        title: 'Workshop',
+        start_date: '2024-03-01',
+        end_date: '2024-03-01',
+        all_day: false,
+        category: 'training',
+        status: 'confirmed',
+        is_public: true,
+        color: '#000000'
+      } as Omit<CalendarEvent, 'id' | 'created_at' | 'updated_at'>;
+
+      const result = await service.createEvent(input);
+
+      expect(eventsQuery.insert).toHaveBeenCalledWith(input);
+      expect(eventsQuery.select).toHaveBeenCalled();
+      expect(eventsQuery.single).toHaveBeenCalled();
+      expect(supabaseRequestMock).toHaveBeenCalledWith(expect.any(Function), 'createCalendarEvent');
+      expect(result).toEqual(createdEvent);
+    });
+
+    it('updates events based on identifier', async () => {
+      const updatedEvent = {
+        id: 'evt-10',
+        type: 'ferias',
+        title: 'Férias atualizadas',
+        start_date: '2024-04-01',
+        end_date: '2024-04-10',
+        all_day: true,
+        category: 'vacation',
+        status: 'approved',
+        is_public: true,
+        color: '#F59E0B',
+        created_at: '2024-02-01',
+        updated_at: '2024-02-15'
+      } as CalendarEvent;
+
+      const eventsQuery = createQueryBuilder({
+        singleResult: { data: updatedEvent, error: null }
+      });
+
+      const supabaseMock = createSupabaseMock({
+        calendar_events: eventsQuery
+      });
+
+      const service = await loadService(supabaseMock as any);
+
+      const updates: Partial<CalendarEvent> = {
+        title: 'Férias atualizadas',
+        status: 'approved'
+      };
+
+      const result = await service.updateEvent('evt-10', updates);
+
+      expect(eventsQuery.update).toHaveBeenCalledWith(updates);
+      expect(eventsQuery.eq).toHaveBeenCalledWith('id', 'evt-10');
+      expect(eventsQuery.select).toHaveBeenCalled();
+      expect(eventsQuery.single).toHaveBeenCalled();
+      expect(result).toEqual(updatedEvent);
+      expect(supabaseRequestMock).toHaveBeenCalledWith(expect.any(Function), 'updateCalendarEvent');
+    });
+
+    it('deletes events using Supabase', async () => {
+      const eventsQuery = createQueryBuilder({
+        eqReturn: Promise.resolve({ data: null, error: null })
+      });
+
+      const supabaseMock = createSupabaseMock({
+        calendar_events: eventsQuery
+      });
+
+      const service = await loadService(supabaseMock as any);
+
+      await service.deleteEvent('evt-9');
+
+      expect(eventsQuery.delete).toHaveBeenCalled();
+      expect(eventsQuery.eq).toHaveBeenCalledWith('id', 'evt-9');
+      expect(supabaseRequestMock).toHaveBeenCalledWith(expect.any(Function), 'deleteCalendarEvent');
+    });
+  });
+
+  describe('RPC helpers', () => {
+    it('validates vacation request via RPC', async () => {
+      const rpcMock = jest.fn().mockResolvedValue({ data: { valid: true }, error: null });
+      const supabaseMock = createSupabaseMock({}, rpcMock);
+      const service = await loadService(supabaseMock as any);
+
+      const result = await service.validateVacationRequest('user-1', '2024-05-01', '2024-05-10', 7);
+
+      expect(rpcMock).toHaveBeenCalledWith('validate_vacation_request', {
+        requester_id: 'user-1',
+        start_date: '2024-05-01',
+        end_date: '2024-05-10',
+        days_requested: 7
+      });
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('throws when vacation validation RPC returns error', async () => {
+      const rpcError = new Error('validation failed');
+      const rpcMock = jest.fn().mockResolvedValue({ data: null, error: rpcError });
+      const supabaseMock = createSupabaseMock({}, rpcMock);
+      const service = await loadService(supabaseMock as any);
+
+      await expect(
+        service.validateVacationRequest('user-1', '2024-05-01', '2024-05-10', 7)
+      ).rejects.toThrow('validation failed');
+      expect(rpcMock).toHaveBeenCalled();
+    });
+
+    it('calculates business days and returns zero on RPC failure', async () => {
+      const rpcMock = jest.fn()
+        .mockResolvedValueOnce({ data: 5, error: null })
+        .mockResolvedValueOnce({ data: null, error: new Error('rpc failed') });
+
+      const supabaseMock = createSupabaseMock({}, rpcMock);
+      const service = await loadService(supabaseMock as any);
+
+      const success = await service.calculateBusinessDays('2024-06-01', '2024-06-10');
+      expect(success).toBe(5);
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const fallback = await service.calculateBusinessDays('2024-07-01', '2024-07-05');
+      expect(fallback).toBe(0);
+      expect(errorSpy).toHaveBeenCalledWith('📅 HRCalendar: Error calculating business days:', expect.any(Error));
+      errorSpy.mockRestore();
+
+      expect(rpcMock).toHaveBeenNthCalledWith(1, 'calculate_business_days', {
+        start_date: '2024-06-01',
+        end_date: '2024-06-10'
+      });
+      expect(rpcMock).toHaveBeenNthCalledWith(2, 'calculate_business_days', {
+        start_date: '2024-07-01',
+        end_date: '2024-07-05'
+      });
+    });
+  });
+
+  describe('automatic generation helpers', () => {
+    it('returns RPC data for birthday events and falls back to zero on error', async () => {
+      const rpcMock = jest.fn()
+        .mockResolvedValueOnce({ data: 4, error: null })
+        .mockResolvedValueOnce({ data: null, error: new Error('birthday failure') });
+
+      const supabaseMock = createSupabaseMock({}, rpcMock);
+      const service = await loadService(supabaseMock as any);
+
+      const created = await service.createBirthdayEvents();
+      expect(created).toBe(4);
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const fallback = await service.createBirthdayEvents();
+      expect(fallback).toBe(0);
+      expect(errorSpy).toHaveBeenCalledWith('📅 HRCalendar: Error creating birthday events:', expect.any(Error));
+      errorSpy.mockRestore();
+
+      expect(rpcMock).toHaveBeenNthCalledWith(1, 'create_birthday_events');
+      expect(rpcMock).toHaveBeenNthCalledWith(2, 'create_birthday_events');
+    });
+
+    it('returns RPC data for company anniversary events and falls back to zero on error', async () => {
+      const rpcMock = jest.fn()
+        .mockResolvedValueOnce({ data: 2, error: null })
+        .mockResolvedValueOnce({ data: null, error: new Error('anniversary failure') });
+
+      const supabaseMock = createSupabaseMock({}, rpcMock);
+      const service = await loadService(supabaseMock as any);
+
+      const created = await service.createCompanyAnniversaryEvents();
+      expect(created).toBe(2);
+
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const fallback = await service.createCompanyAnniversaryEvents();
+      expect(fallback).toBe(0);
+      expect(errorSpy).toHaveBeenCalledWith('📅 HRCalendar: Error creating anniversary events:', expect.any(Error));
+      errorSpy.mockRestore();
+
+      expect(rpcMock).toHaveBeenNthCalledWith(1, 'create_company_anniversary_events');
+      expect(rpcMock).toHaveBeenNthCalledWith(2, 'create_company_anniversary_events');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive Jest coverage for the HR calendar service, exercising filters, mutations, RPC fallbacks, and auto-generation helpers
- implement a Cypress HR workflows spec that drives approvals/rejections with intercepts and validates dashboard refreshes
- extend Cypress fixtures and the setTestUser helper to cover HR/admin role scenarios

## Testing
- npm test -- --runTestsByPath src/services/__tests__/hrCalendarService.test.ts *(fails: Module ts-jest in the transform option was not found)*

------
https://chatgpt.com/codex/tasks/task_b_68dd44cb47c88323937b4e2a1445f979