### PR TITLE
Fix mental health admin module fetch error

### DIFF
--- a/src/services/mentalHealth.ts
+++ b/src/services/mentalHealth.ts
@@ -1321,8 +1321,8 @@ export const mentalHealthService = {
     if (score >= 60) return 'alto';
     if (score >= 40) return 'medio';
     return 'baixo';
-  }
-};
+  },
+
   // Enhanced Wellness Resources with view tracking
   async getWellnessResourcesWithStats(category?: string): Promise<WellnessResource[]> {
     console.log('🧠 MentalHealth: Getting wellness resources with stats, category:', category);


### PR DESCRIPTION
Fix syntax error in `mentalHealth.ts` to resolve "Failed to fetch dynamically imported module" for `MentalHealthAdmin.tsx`.

The `mentalHealthService` object was prematurely closed, causing the `getWellnessResourcesWithStats` function to be defined outside of it. This syntax error prevented the `MentalHealthAdmin` module from compiling and loading correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-443c7913-4fd6-4099-8456-ca59d3b05abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-443c7913-4fd6-4099-8456-ca59d3b05abd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

