### PR TITLE
Fix mental health admin bookopen error

### DIFF
--- a/src/pages/MentalHealthAdmin.tsx
+++ b/src/pages/MentalHealthAdmin.tsx
@@ -21,7 +21,8 @@ import {
   Minus,
   ClipboardList,
   CheckSquare,
-  ArrowRight
+  ArrowRight,
+  BookOpen
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { 


### PR DESCRIPTION
Import `BookOpen` icon to resolve "BookOpen is not defined" error in `MentalHealthAdmin.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-956313d6-e9bc-41fe-8552-27f882c4c326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-956313d6-e9bc-41fe-8552-27f882c4c326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

