### PR TITLE
Fix mental health form builder import error

### DIFF
--- a/src/components/LazyComponents.tsx
+++ b/src/components/LazyComponents.tsx
@@ -38,5 +38,5 @@ export const LazyActionGroupService = lazy(() => import('../services/actionGroup
 // Advanced Mental Health Features
 export const LazyPsychologicalRecord = lazy(() => import('../pages/PsychologicalRecord'));
 export const LazyAnalyticsDashboard = lazy(() => import('../pages/AnalyticsDashboard'));
-export const LazyFormBuilder = lazy(() => import('../components/mental-health/FormBuilder'));
-export const LazyTaskManager = lazy(() => import('../components/mental-health/TaskManager'));
+export const LazyFormBuilder = lazy(() => import('./mental-health/FormBuilder'));
+export const LazyTaskManager = lazy(() => import('./mental-health/TaskManager'));

--- a/src/components/mental-health/FormBuilder.tsx
+++ b/src/components/mental-health/FormBuilder.tsx
@@ -15,7 +15,7 @@ import {
   Move,
   GripVertical
 } from 'lucide-react';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../../contexts/AuthContext';
 import { mentalHealthService, FormTemplate, FormQuestion } from '../../services/mentalHealth';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';


### PR DESCRIPTION
Corrects relative import paths for `AuthContext` and lazy-loaded mental health components to resolve dynamic module fetching errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca854a2a-ddce-4e04-bdce-5837267d8168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca854a2a-ddce-4e04-bdce-5837267d8168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

