### PR TITLE
Address review feedback on assignment access and navigation

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -105,10 +105,17 @@ export const Sidebar: React.FC<SidebarProps> = ({ onNavigate, isMobile = false }
     user && item.roles.includes(user.role)
   );
 
+  const getVisibleSubItems = (item: SidebarItem) => {
+    if (!item.subItems) return [];
+    if (!user) return item.subItems;
+    return item.subItems.filter(subItem => subItem.roles.includes(user.role));
+  };
+
   const isItemActive = (item: SidebarItem) => {
     if (location.pathname === item.path) return true;
     if (item.subItems) {
-      return item.subItems.some(subItem => location.pathname === subItem.path);
+      const visibleSubItems = getVisibleSubItems(item);
+      return visibleSubItems.some(subItem => location.pathname === subItem.path);
     }
     return false;
   };
@@ -137,7 +144,8 @@ export const Sidebar: React.FC<SidebarProps> = ({ onNavigate, isMobile = false }
         {filteredItems.map((item) => {
           const isActive = isItemActive(item);
           const isExpanded = expandedItems.includes(item.id);
-          const hasSubItems = item.subItems && item.subItems.length > 0;
+          const visibleSubItems = getVisibleSubItems(item);
+          const hasSubItems = visibleSubItems.length > 0;
 
           return (
             <div key={item.id}>
@@ -200,7 +208,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ onNavigate, isMobile = false }
                     className="overflow-hidden"
                   >
                     <div className="ml-6 mt-1 space-y-1">
-                      {item.subItems!.map((subItem) => {
+                      {visibleSubItems.map((subItem) => {
                         const isSubActive = location.pathname === subItem.path;
                         return (
                           <Link

--- a/src/services/formAssignment.ts
+++ b/src/services/formAssignment.ts
@@ -257,13 +257,11 @@ export class FormAssignmentService {
       if (userRole === 'admin') {
         // Admin can ONLY see performance forms, NEVER mental health data
         query = query.eq('form_type', 'performance');
-        
-        // If specific formType is requested and it's mental_health, return empty
+
         if (formType === 'mental_health') {
           return {
             success: true,
-            assignments: [],
-            error: 'Administradores não podem acessar dados de saúde mental'
+            assignments: []
           };
         }
       } else if (userRole === 'hr') {
@@ -279,8 +277,15 @@ export class FormAssignmentService {
         query = query.contains('assigned_to', [userId]);
       }
 
-      // Additional security: If formType is specified, apply it
+      // Additional security: If formType is specified, apply it with role validation
       if (formType) {
+        if (formType === 'mental_health' && userRole !== 'hr') {
+          return {
+            success: true,
+            assignments: []
+          };
+        }
+
         query = query.eq('form_type', formType);
       }
 


### PR DESCRIPTION
## Summary
- lock down `FormAssignmentService.getUserAssignments` so non-HR roles never receive mental health assignments
- defer detailed permission validation in `FormAssignmentModal` until users are selected and surface helpful status messaging
- filter sidebar sub-items by the viewer's role so managers can reach the Manager Feedback page without exposing HR-only links

## Testing
- npm run lint *(fails: @typescript-eslint/no-unused-expressions cannot load with current TypeScript version)*

------
https://chatgpt.com/codex/tasks/task_b_68e66bf5b17c8323b768d1beb5b06b87