### PR TITLE
Fix HR mental health routing and state issues

### DIFF
--- a/src/components/mental-health/CheckInWidget.tsx
+++ b/src/components/mental-health/CheckInWidget.tsx
@@ -130,6 +130,7 @@ export const CheckInWidget: React.FC<CheckInWidgetProps> = ({
   const [showHistory, setShowHistory] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showTrends, setShowTrends] = useState(false);
+  const [showHRConfig, setShowHRConfig] = useState(false);
   const [notes, setNotes] = useState('');
   const [questionAnswer, setQuestionAnswer] = useState('');
   const [scores, setScores] = useState({

--- a/src/components/mental-health/FormBuilder.tsx
+++ b/src/components/mental-health/FormBuilder.tsx
@@ -15,7 +15,7 @@ import {
   Move,
   GripVertical
 } from 'lucide-react';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../../contexts/AuthContext';
 import { mentalHealthService, FormTemplate, FormQuestion } from '../../services/mentalHealth';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';


### PR DESCRIPTION
## Summary
- add missing state management for the HR configuration panel in the mental health check-in widget
- correct the AuthContext import path in the mental health form builder so the module resolves properly

## Testing
- npm run build *(fails: existing duplicate key definitions in src/services/mentalHealth.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68e67a41be788323a1e3dc7e17b0390e